### PR TITLE
build-push: move :latest on workflow_dispatch from main, not just push events

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -176,17 +176,23 @@ jobs:
           # --- moving-pointer aliases (re-pointed on every build) ---
           tags=( "${repo_lc}:${canonical_tag}" )
           case "${{ github.event_name }}" in
-            push)
+            push|workflow_dispatch)
+              # Branch alias (":main", ":feature-foo"). For push it's the
+              # pushed branch; for workflow_dispatch it's the dispatched
+              # ref. Both share this alias so a manual re-run of main
+              # behaves the same as an auto-push to main.
               tags+=( "${repo_lc}:${sanitized_ref}" )
+              # Move ":latest" whenever the destination branch is main.
+              # Previously this only fired for `push`, so workflow_dispatch
+              # builds on main never updated ":latest" — leaving consumers
+              # that pull ":latest" with a stale image and skewing the
+              # cc-catalog-svc / cc-registry-v2 view of which tag is newest.
               if [ "${{ github.ref_name }}" = "main" ]; then
                 tags+=( "${repo_lc}:latest" )
               fi
               ;;
             pull_request)
               tags+=( "${repo_lc}:pr-${{ github.event.pull_request.number }}" )
-              ;;
-            workflow_dispatch)
-              tags+=( "${repo_lc}:${sanitized_ref}" )
               ;;
           esac
 


### PR DESCRIPTION
## Summary

The tag-set case statement in `.github/workflows/build-push.yaml` only added the `:latest` alias for `push` events. Manually re-running the workflow on `main` via `workflow_dispatch` produced a fully-tagged canonical build but did **not** update the moving `:latest` pointer.

## The bug

Before:

```yaml
case "${{ github.event_name }}" in
  push)
    tags+=( "${repo_lc}:${sanitized_ref}" )
    if [ "${{ github.ref_name }}" = "main" ]; then
      tags+=( "${repo_lc}:latest" )
    fi
    ;;
  pull_request) ... ;;
  workflow_dispatch)
    tags+=( "${repo_lc}:${sanitized_ref}" )     # :latest NEVER appended
    ;;
esac
```

After: `push` and `workflow_dispatch` share an arm, so both apply the branch alias and `:latest` (gated on `github.ref_name == "main"` as before). `pull_request` stays separate.

## Why it matters

- Consumers pulling `:latest` directly were stuck on the last automatic push to main.
- `cc-catalog-svc` and `cc-registry-v2` use the canonical tag list (not `:latest`), so they now report a newer canonical tag while `:latest` still points at the older one — an inconsistency that surprised an operator when manually re-running a main build.

## Compatibility

| Trigger | Before | After |
|---|---|---|
| `push` to main | `<canonical> + :main + :latest` | unchanged |
| `push` to `feature-x` | `<canonical> + :feature-x` | unchanged |
| `pull_request` | `<canonical> + :pr-N` | unchanged |
| `workflow_dispatch` from main | `<canonical> + :main` | `<canonical> + :main + :latest` |
| `workflow_dispatch` from `feature-x` | `<canonical> + :feature-x` | unchanged |

Only new behavior: `workflow_dispatch` on main now updates `:latest`.

## Test plan

- [ ] Merge to main
- [ ] Run a manual `workflow_dispatch` on main and confirm `:latest` ends up pointing at the freshly-built canonical tag in GHCR
- [ ] Confirm the existing automatic-push behaviour on `main` is unchanged

## Companion PRs

This change ships in lockstep across all 6 RunWhen codecollection repos so the registry behaviour is consistent. The catalog-side handling (in `runwhen-contrib/codecollection-registry` PR ccv/git-mirror) makes the same fix less critical by sorting canonical tags on real `built_at` timestamps, but moving `:latest` correctly here is still the right thing to do for direct `docker pull` users and for visual consistency in GHCR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that affects GHCR tagging; main impact is that manual `workflow_dispatch` runs on `main` will now move `:latest`, which could change what downstream consumers pull by that alias.
> 
> **Overview**
> Ensures GHCR tagging is consistent between automatic pushes and manual runs by treating `workflow_dispatch` like `push` when computing tags.
> 
> Manual `workflow_dispatch` builds now also publish the branch alias and update `:latest` when the ref is `main`, fixing cases where `:latest` could remain stale after a manual rebuild.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 056371814a4b329901e667b78e30d4c1512d33e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->